### PR TITLE
feat: statusv1 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,22 @@
 
 Porcelain provides parsers for Git's [porcelain status output] in Go.
 
-  - [github.com/mroth/porcelain/statusv1] provides only legacy `porcelain=v1` status
-    codes, and intentionally does not implement parsing.
-  - [github.com/mroth/porcelain/statusv2] implements `porcelain=v2` format parsing.
+  - [github.com/mroth/porcelain/statusv1] provides `porcelain=v1` format parsing.
+  - [github.com/mroth/porcelain/statusv2] provides `porcelain=v2` format parsing.
 
 The parsers are performant (parsing a typical git status report including
 headers in ~2µs single-threaded), and robust (fuzz tested to avoid any possible
 crashing panics).
 
-It is undetermined whether legacy support for `porcelain=v1` parsing will be
-added to this library in the future, as it is a historic format with [some
-issues]. I will only add support if I become convinced that it can be
-accomplished with a similar degree of robustness, otherwise parsing will remain
-unimplemented to discourage usage.
+Support for both regular (LF delimited) and `-z` (NUL delimited) output formats
+is provided.
 
-Rudimentary support for v1 "-z format" is currently used in the internals for my
-[github.com/mroth/scmpuff] project, which was written prior to `porcelain=v2`,
-if you're looking for a starting point down that rabbit hole.
-
-The `porcelain=v2` format was first introduced in Git v2.11.0 (2016).
+The `porcelain=v2` format was first introduced in Git v2.11.0 (2016), and is
+recommended for most use cases, as it is significantly more robust and addresses
+[some inconsistencies] with the historic `porcelain=v1` format.
 
 [porcelain status output]: https://git-scm.com/docs/git-status#_porcelain_format_version_2
 [github.com/mroth/porcelain/statusv1]: https://pkg.go.dev/github.com/mroth/porcelain/statusv1
 [github.com/mroth/porcelain/statusv2]: https://pkg.go.dev/github.com/mroth/porcelain/statusv2
 [github.com/mroth/scmpuff]: https://github.com/mroth/scmpuff
-[some issues]: https://public-inbox.org/git/20100409184608.C7C61475FEF@snark.thyrsus.com/
+[some inconsistencies]: https://public-inbox.org/git/20100409184608.C7C61475FEF@snark.thyrsus.com/

--- a/statusv1/bench_test.go
+++ b/statusv1/bench_test.go
@@ -1,0 +1,55 @@
+package statusv1
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func BenchmarkParse_Sample(b *testing.B) {
+	r := bytes.NewReader(samplePorcelainV1Output)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		Parse(r)
+		r.Seek(0, io.SeekStart) // reset reader for next iteration
+	}
+}
+
+func BenchmarkParseZ_Sample(b *testing.B) {
+	r := bytes.NewReader(samplePorcelainV1ZOutput)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ParseZ(r)
+		r.Seek(0, io.SeekStart) // reset reader for next iteration
+	}
+}
+
+func Benchmark_parseEntry_Modified(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		parseEntry(sampleEntryModified)
+	}
+}
+
+func Benchmark_parseEntry_Renamed(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		parseEntry(sampleEntryRenamed)
+	}
+}
+
+func Benchmark_parseEntryZ_Modified(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		parseEntryZ(sampleEntryModified)
+	}
+}
+
+func Benchmark_parseEntryZ_Renamed(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		parseEntryZ(sampleEntryRenamedZ)
+	}
+}

--- a/statusv1/doc.go
+++ b/statusv1/doc.go
@@ -1,0 +1,61 @@
+/*
+Package statusv1 parses the output of `git status --porcelain=v1`.
+
+This package provides parsing for Git's machine-readable status format,
+supporting both regular line-terminated output and NUL-terminated output (with
+-z flag). This package implements parsing of the original porcelain=v1 format,
+which is simpler than the more modern porcelain=v2 format.
+
+# Basic Usage
+
+[Parse] takes an [io.Reader] containing `git status --porcelain=v1` output.
+
+	r := bytes.NewReader(gitStatusOutput)
+	status, err := statusv2.Parse(r)
+	if err != nil {
+	    log.Fatal(err)
+	}
+
+[ParseZ] provides a variant that will work with NUL-terminated git status output
+(from -z flag).
+
+# Working with Results
+
+The [Status] struct contains parsed information, notably the list of file
+entries, which can be accessed via the [Status.Entries] field. Each entry is
+represented by an [Entry] struct, which contains the XY status flags and file
+paths.
+
+# Git Status Format
+
+This package parses Git's porcelain=v1 format, which provides machine-readable
+output with basic information about file status and branch state. The format is
+stable across Git versions and designed for programmatic consumption.
+
+The porcelain=v1 format outputs one line per file:
+
+	XY PATH
+	XY ORIG_PATH -> PATH  (for renames/copies)
+
+Where XY is a two-character status code indicating the state of the file in the
+index (X) and working tree (Y).
+
+There is also an alternate -z format recommended for machine parsing. In that
+format, the status field is the same, but some other things change. First, the
+-> is omitted from rename entries and the field order is reversed (e.g from ->
+to becomes to from). Second, a NUL (ASCII 0) follows each filename, replacing
+space as a field separator and the terminating newline (but a space still
+separates the status field from the first filename). Third, filenames containing
+special characters are not specially formatted; no quoting or backslash-escaping
+is performed.
+
+In most cases, users should prefer the more modern porcelain=v2 format, which
+provides more detailed information and additional features. See the [statusv2]
+package for parsing porcelain=v2 output.
+
+For more information about the porcelain=v1 format, see the Git documentation
+for [git status].
+
+[git status]: https://git-scm.com/docs/git-status#_porcelain_format_version_1
+*/
+package statusv1

--- a/statusv1/fuzz_test.go
+++ b/statusv1/fuzz_test.go
@@ -1,0 +1,43 @@
+package statusv1
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzParse tests the Parse function with arbitrary input
+func FuzzParse(f *testing.F) {
+	// Add seed inputs covering various entry types
+	f.Add([]byte(" M file.txt\nA  added.txt\nD  deleted.txt"))
+	f.Add([]byte("R  new.txt -> old.txt\n?? untracked.txt"))
+	f.Add([]byte("!! ignored.txt\nMM conflict.txt"))
+	f.Add([]byte("C  copy.txt -> orig.txt"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Parser should never panic, only return an error for invalid input
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Parse panicked with input %q: %v", data, r)
+			}
+		}()
+		Parse(bytes.NewReader(data))
+	})
+}
+
+// FuzzParseZ tests the ParseZ function with arbitrary input
+func FuzzParseZ(f *testing.F) {
+	// Add seed inputs in -z format
+	f.Add([]byte(" M file.txt\x00A  added.txt\x00"))
+	f.Add([]byte("R  new.txt\x00old.txt\x00?? untracked.txt\x00"))
+	f.Add([]byte("C  copy.txt\x00orig.txt\x00"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Parser should never panic, only return an error for invalid input
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("ParseZ panicked with input %q: %v", data, r)
+			}
+		}()
+		ParseZ(bytes.NewReader(data))
+	})
+}

--- a/statusv1/parse.go
+++ b/statusv1/parse.go
@@ -1,0 +1,186 @@
+package statusv1
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// Parse parses git status --porcelain=v1 output from an io.Reader.
+//
+// Headers: When using --branch in conjunction with git status --porcelain=v1,
+// the output may contain header lines, for example, `## main...origin/main
+// [ahead 1]`. These lines are preserved with ordering intact in the Headers
+// field of the returned Status struct, but are not parsed as they are not
+// documented as part of the --porcelain=v1 format.
+//
+// Path Handling: Paths containing special characters may be quoted by Git
+// according to core.quotePath configuration. This function preserves paths
+// exactly as provided by Git without unquoting. If your application needs
+// unquoted paths, consider using [ParseZ] with the -z flag instead, as Git
+// does not quote paths in -z format.
+func Parse(r io.Reader) (*Status, error) {
+	scanner := bufio.NewScanner(r)
+	status := &Status{}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue // skip empty lines
+		}
+
+		if bytes.HasPrefix(line, []byte("##")) {
+			status.Headers = append(status.Headers, string(line))
+			continue
+		}
+
+		entry, err := parseEntry(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse line %q: %w", line, err)
+		}
+
+		status.Entries = append(status.Entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanner error: %w", err)
+	}
+
+	return status, nil
+}
+
+// ParseZ parses git status --porcelain=v1 -z output from an io.Reader.
+//
+// In the -z format, entries are terminated by NUL bytes instead of newlines,
+// and rename entries have the format "XY to\x00from\x00" instead of "XY from -> to".
+//
+// Headers: When using --branch in conjunction with git status --porcelain=v1,
+// the output may contain header lines, for example, `## main...origin/main
+// [ahead 1]`. These lines are preserved with ordering intact in the Headers
+// field of the returned Status struct, but are not parsed as they are not
+// documented as part of the --porcelain=v1 format.
+//
+// Path Handling: In -z format, Git does not quote paths containing special
+// characters, so all paths are provided as-is. This function preserves paths
+// exactly as provided by Git.
+func ParseZ(r io.Reader) (*Status, error) {
+	scanner := newZScanner(r)
+	status := &Status{}
+
+	for scanner.Scan() {
+		entry := scanner.Bytes()
+		if len(entry) == 0 {
+			continue // skip empty entries
+		}
+
+		if bytes.HasPrefix(entry, []byte("##")) {
+			status.Headers = append(status.Headers, string(entry))
+			continue
+		}
+
+		parsedEntry, err := parseEntryZ(entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse entry %q: %w", entry, err)
+		}
+
+		status.Entries = append(status.Entries, parsedEntry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanner error: %w", err)
+	}
+
+	return status, nil
+}
+
+// parseEntry parses a single line from git status --porcelain=v1 output.
+// Format: "XY PATH" or "XY ORIG_PATH -> PATH"
+func parseEntry(line []byte) (Entry, error) {
+	if len(line) < 3 {
+		return Entry{}, fmt.Errorf("line too short: %q", line)
+	}
+
+	// Parse XY status
+	xy, err := parseXYFlag(line[:2])
+	if err != nil {
+		return Entry{}, err
+	}
+
+	// Skip the space after XY
+	if line[2] != ' ' {
+		return Entry{}, fmt.Errorf("expected space after XY status, got %q", line[2])
+	}
+
+	pathPart := line[3:]
+
+	// Check for rename/copy format: "ORIG_PATH -> PATH"
+	separator := []byte(" -> ")
+	if origPath, newPath, found := bytes.Cut(pathPart, separator); found {
+		// Check for empty parts
+		if len(origPath) == 0 || len(newPath) == 0 {
+			return Entry{}, fmt.Errorf("invalid rename format: %q", pathPart)
+		}
+
+		return Entry{
+			XY:       xy,
+			Path:     string(newPath),
+			OrigPath: string(origPath),
+		}, nil
+	}
+
+	// Regular format: just "PATH"
+	return Entry{
+		XY:   xy,
+		Path: string(pathPart),
+	}, nil
+}
+
+// parseEntryZ parses a single entry from git status --porcelain=v1 -z output.
+// In -z format, rename entries contain both paths: "XY to\x00from".
+func parseEntryZ(entry []byte) (Entry, error) {
+	if len(entry) < 3 {
+		return Entry{}, fmt.Errorf("entry too short: %q", entry)
+	}
+
+	// Parse XY status
+	xy, err := parseXYFlag(entry[:2])
+	if err != nil {
+		return Entry{}, err
+	}
+
+	// Skip the space after XY
+	if entry[2] != ' ' {
+		return Entry{}, fmt.Errorf("expected space after XY status, got %q", entry[2])
+	}
+
+	pathPart := entry[3:]
+
+	// For renames/copies in -z format, we have "to\x00from"
+	// R or C can appear in either X or Y position
+	if xy.X == Renamed || xy.X == Copied || xy.Y == Renamed || xy.Y == Copied {
+		if newPath, origPath, found := bytes.Cut(pathPart, []byte{'\x00'}); found {
+			// This is a rename: "to\x00from"
+			return Entry{
+				XY:       xy,
+				Path:     string(newPath),
+				OrigPath: string(origPath),
+			}, nil
+		}
+		// If we don't have the NUL separator, it might be a malformed entry
+		// but we'll treat it as just the new path
+	}
+
+	// Regular format: just the path (or malformed rename with only new path)
+	return Entry{
+		XY:   xy,
+		Path: string(pathPart),
+	}, nil
+}
+
+func parseXYFlag(field []byte) (XYFlag, error) {
+	if len(field) != 2 {
+		return XYFlag{}, fmt.Errorf("invalid XY field: expected 2 characters, got %d", len(field))
+	}
+	return XYFlag{X: State(field[0]), Y: State(field[1])}, nil
+}

--- a/statusv1/parse_test.go
+++ b/statusv1/parse_test.go
@@ -1,0 +1,339 @@
+package statusv1
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Sample porcelain=v1 lines
+var (
+	sampleHeaderBranch      = []byte("## main...origin/main [ahead 1]")
+	sampleHeaderUnknown     = []byte("## unknown header line")
+	sampleEntryModified     = []byte(" M file_modified.txt")
+	sampleEntryAdded        = []byte("A  file_added.txt")
+	sampleEntryDeleted      = []byte("D  file_deleted.txt")
+	sampleEntryRenamed      = []byte("R  file_original.txt -> file_renamed.txt")
+	sampleEntryCopied       = []byte("C  file_original.txt -> file_copied.txt")
+	sampleEntryUntracked    = []byte("?? file_untracked.txt")
+	sampleEntryIgnored      = []byte("!! file_ignored.txt")
+	sampleEntryBothModified = []byte("MM file_both_modified.txt")
+)
+
+// Some entries that differ in -z format for benchmarking ParseZ
+var (
+	sampleEntryRenamedZ = []byte("R  file_renamed.txt\x00file_original.txt")
+	sampleEntryCopiedZ  = []byte("C  file_copied.txt\x00file_original.txt")
+)
+
+// samplePorcelainV1Output is a contrived sample output of:
+// `git status --porcelain=v1 --branch`.
+// It contains one entry for each common status type, a branch header, and a junk header to test parsing.
+var samplePorcelainV1Output = bytes.Join([][]byte{
+	sampleHeaderBranch,
+	sampleHeaderUnknown,
+	sampleEntryModified,
+	sampleEntryAdded,
+	sampleEntryDeleted,
+	sampleEntryRenamed,
+	sampleEntryCopied,
+	sampleEntryUntracked,
+	sampleEntryIgnored,
+	sampleEntryBothModified,
+}, []byte("\n"))
+
+// samplePorcelainV1ZOutput is a contrived sample output of:
+// `git status --porcelain=v1 --branch -z`.
+// It contains one entry for each common status type, a branch header, and a junk header to test parsing.
+// It should parse to the same result as samplePorcelainV1Output, but uses NUL terminators and the -z format for renames/copies.
+var samplePorcelainV1ZOutput = bytes.Join([][]byte{
+	sampleHeaderBranch,
+	sampleHeaderUnknown,
+	sampleEntryModified,
+	sampleEntryAdded,
+	sampleEntryDeleted,
+	sampleEntryRenamedZ,
+	sampleEntryCopiedZ,
+	sampleEntryUntracked,
+	sampleEntryIgnored,
+	sampleEntryBothModified,
+}, []byte("\x00"))
+
+var sampleParsedStatus = Status{
+	Headers: []string{
+		"## main...origin/main [ahead 1]",
+		"## unknown header line",
+	},
+	Entries: []Entry{
+		{XY: XYFlag{Unmodified, Modified}, Path: "file_modified.txt"},
+		{XY: XYFlag{Added, Unmodified}, Path: "file_added.txt"},
+		{XY: XYFlag{Deleted, Unmodified}, Path: "file_deleted.txt"},
+		{XY: XYFlag{Renamed, Unmodified}, Path: "file_renamed.txt", OrigPath: "file_original.txt"},
+		{XY: XYFlag{Copied, Unmodified}, Path: "file_copied.txt", OrigPath: "file_original.txt"},
+		{XY: XYFlag{Untracked, Untracked}, Path: "file_untracked.txt"},
+		{XY: XYFlag{Ignored, Ignored}, Path: "file_ignored.txt"},
+		{XY: XYFlag{Modified, Modified}, Path: "file_both_modified.txt"},
+	},
+}
+
+func TestParse(t *testing.T) {
+	r := bytes.NewReader(samplePorcelainV1Output)
+	want := &sampleParsedStatus
+	got, err := Parse(r)
+	if err != nil {
+		t.Errorf("Parse() error = %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+	}
+
+}
+
+func TestParseZ(t *testing.T) {
+	r := bytes.NewReader(samplePorcelainV1ZOutput)
+	want := &sampleParsedStatus
+	got, err := ParseZ(r)
+	if err != nil {
+		t.Errorf("ParseZ() error = %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ParseZ() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func Test_parseEntry(t *testing.T) {
+	testcases := []struct {
+		name    string
+		input   string
+		want    Entry
+		wantErr bool
+	}{
+		{
+			name:  "modified in worktree",
+			input: " M file.txt",
+			want:  Entry{XY: XYFlag{Unmodified, Modified}, Path: "file.txt"},
+		},
+		{
+			name:  "added to index",
+			input: "A  file.txt",
+			want:  Entry{XY: XYFlag{Added, Unmodified}, Path: "file.txt"},
+		},
+		{
+			name:  "renamed",
+			input: "R  old.txt -> new.txt",
+			want:  Entry{XY: XYFlag{Renamed, Unmodified}, Path: "new.txt", OrigPath: "old.txt"},
+		},
+		{
+			name:  "copied",
+			input: "C  orig.txt -> copy.txt",
+			want:  Entry{XY: XYFlag{Copied, Unmodified}, Path: "copy.txt", OrigPath: "orig.txt"},
+		},
+		{
+			name:  "untracked",
+			input: "?? untracked.txt",
+			want:  Entry{XY: XYFlag{Untracked, Untracked}, Path: "untracked.txt"},
+		},
+		{
+			name:  "ignored",
+			input: "!! ignored.txt",
+			want:  Entry{XY: XYFlag{Ignored, Ignored}, Path: "ignored.txt"},
+		},
+		{
+			name:  "quoted path",
+			input: "A  \"path with spaces.txt\"",
+			want:  Entry{XY: XYFlag{Added, Unmodified}, Path: "\"path with spaces.txt\""},
+		},
+		{
+			name:  "quoted path with escape",
+			input: "A  \"path\\nwith\\nnewline.txt\"",
+			want:  Entry{XY: XYFlag{Added, Unmodified}, Path: "\"path\\nwith\\nnewline.txt\""},
+		},
+		{
+			name:  "renamed with quoted paths",
+			input: "R  \"old path.txt\" -> \"new path.txt\"",
+			want:  Entry{XY: XYFlag{Renamed, Unmodified}, Path: "\"new path.txt\"", OrigPath: "\"old path.txt\""},
+		},
+		// Edge cases
+		{
+			name:    "line too short",
+			input:   "M",
+			wantErr: true,
+		},
+		{
+			name:    "missing space after XY",
+			input:   "M file.txt",
+			wantErr: true,
+		},
+		{
+			name:    "invalid rename format - empty target",
+			input:   "R  old.txt -> ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid rename format - empty source",
+			input:   "R   -> new.txt",
+			wantErr: true,
+		},
+		{
+			name:  "malformed rename - missing arrow (treated as path)",
+			input: "R  old.txt new.txt",
+			want:  Entry{XY: XYFlag{Renamed, Unmodified}, Path: "old.txt new.txt"},
+			// this is likely an error in reality, but as per porcelain=v1 spec,
+			// it is parsed as a valid path with no original path.
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseEntry([]byte(tc.input))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseEntry() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("parseEntry() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_parseEntryZ(t *testing.T) {
+	testcases := []struct {
+		name    string
+		input   string
+		want    Entry
+		wantErr bool
+	}{
+		{
+			name:  "modified in worktree",
+			input: " M file.txt",
+			want:  Entry{XY: XYFlag{Unmodified, Modified}, Path: "file.txt"},
+		},
+		{
+			name:  "added to index",
+			input: "A  file.txt",
+			want:  Entry{XY: XYFlag{Added, Unmodified}, Path: "file.txt"},
+		},
+		{
+			name:  "renamed in X position (-z format)",
+			input: "R  new.txt\x00old.txt",
+			want:  Entry{XY: XYFlag{Renamed, Unmodified}, Path: "new.txt", OrigPath: "old.txt"},
+		},
+		{
+			name:  "copied in X position (-z format)",
+			input: "C  copy.txt\x00orig.txt",
+			want:  Entry{XY: XYFlag{Copied, Unmodified}, Path: "copy.txt", OrigPath: "orig.txt"},
+		},
+		{
+			name:  "renamed in Y position (-z format)",
+			input: " R new.txt\x00old.txt",
+			want:  Entry{XY: XYFlag{Unmodified, Renamed}, Path: "new.txt", OrigPath: "old.txt"},
+		},
+		{
+			name:  "copied in Y position (-z format)",
+			input: " C copy.txt\x00orig.txt",
+			want:  Entry{XY: XYFlag{Unmodified, Copied}, Path: "copy.txt", OrigPath: "orig.txt"},
+		},
+		{
+			name:  "untracked",
+			input: "?? untracked.txt",
+			want:  Entry{XY: XYFlag{Untracked, Untracked}, Path: "untracked.txt"},
+		},
+		{
+			name:  "path with spaces (no quoting in -z)",
+			input: "A  path with spaces.txt",
+			want:  Entry{XY: XYFlag{Added, Unmodified}, Path: "path with spaces.txt"},
+		},
+		// Edge cases
+		{
+			name:    "entry too short",
+			input:   "M",
+			wantErr: true,
+		},
+		{
+			name:    "missing space after XY",
+			input:   "M file.txt",
+			wantErr: true,
+		},
+		{
+			name:  "rename entry with missing second path (treated as path)",
+			input: "R  new.txt\x00",
+			want:  Entry{XY: XYFlag{Renamed, Unmodified}, Path: "new.txt"},
+		},
+		{
+			name:  "empty original path with NUL terminator",
+			input: "R  new.txt\x00\x00",
+			want:  Entry{XY: XYFlag{Renamed, Unmodified}, Path: "new.txt", OrigPath: "\x00"},
+		},
+		{
+			name:    "missing space after XY with tab",
+			input:   "M\tfile.txt",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseEntryZ([]byte(tc.input))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseEntryZ() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("parseEntryZ() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_parseXYFlag(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    []byte
+		expected XYFlag
+		wantErr  bool
+	}{
+		{
+			name:     "valid modified",
+			input:    []byte(" M"),
+			expected: XYFlag{X: Unmodified, Y: Modified},
+		},
+		{
+			name:     "valid added",
+			input:    []byte("A "),
+			expected: XYFlag{X: Added, Y: Unmodified},
+		},
+		{
+			name:     "valid untracked",
+			input:    []byte("??"),
+			expected: XYFlag{X: Untracked, Y: Untracked},
+		},
+		{
+			name:    "too short",
+			input:   []byte("M"),
+			wantErr: true,
+		},
+		{
+			name:    "too long",
+			input:   []byte("ABC"),
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   []byte(""),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseXYFlag(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseXYFlag() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("parseXYFlag() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/statusv1/scanner.go
+++ b/statusv1/scanner.go
@@ -1,0 +1,70 @@
+package statusv1
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+)
+
+// newZScanner creates a scanner that tokenizes git status --porcelain=v1 -z
+// output, returning each entry as a token, omitting the NUL byte that serves as
+// the line terminator.
+//
+// It handles the complex case for rename/copy entries (XY status codes where
+// X is 'R' or 'C') which contain two NUL bytes: one as the path separator and
+// another as the line terminator. Regular entries only have the line terminator
+// NUL byte.
+func newZScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(porcelainv1ZSplitFunc)
+	return scanner
+}
+
+// porcelainv1ZSplitFunc is a custom [bufio.SplitFunc] that handles the dual NUL byte issue
+// in porcelain v1 -z output. For rename/copy entries (where the first character of the XY
+// status is 'R' or 'C'), it looks for the second NUL byte as the true line terminator,
+// while for all other entries it uses the first NUL byte as the terminator.
+func porcelainv1ZSplitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	// Look for first NUL byte. For rename/copy entries, this will be the path
+	// separator, and for all other entries, this is the entry terminator.
+	firstNUL := bytes.IndexByte(data, '\x00')
+	if firstNUL == -1 {
+		if atEOF && len(data) > 0 {
+			// No NUL found but we're at EOF, return remaining data
+			return len(data), data, nil
+		}
+		// Need more data
+		return 0, nil, nil
+	}
+
+	// Check if this is a rename/copy entry (XY status where X or Y is 'R' or 'C')
+	// Format: "XY path\x00origpath\x00"
+	if len(data) >= 2 && (data[0] == 'R' || data[0] == 'C' || data[1] == 'R' || data[1] == 'C') {
+		// Look for the second NUL byte (the line terminator)
+		secondNUL := bytes.IndexByte(data[firstNUL+1:], '\x00')
+		if secondNUL == -1 {
+			if atEOF {
+				// At EOF with only one NUL - check if we have both paths
+				if firstNUL+1 < len(data) {
+					// We have data after the first NUL, treat as second path
+					return len(data), data, nil
+				} else {
+					// Only one path, this is corruption
+					return 0, nil, fmt.Errorf("malformed rename/copy entry: missing original path")
+				}
+			}
+			// Need more data to find the second NUL
+			return 0, nil, nil
+		}
+
+		// Return the entire rename/copy entry including the internal NUL path
+		// separator, advancing past the second NUL byte entry terminator.
+		totalLength := firstNUL + 1 + secondNUL
+		return totalLength + 1, data[:totalLength], nil
+	}
+
+	// Normal case: return up to first NUL as the token,
+	// advancing the scanner past the entry terminator.
+	return firstNUL + 1, data[:firstNUL], nil
+}

--- a/statusv1/scanner_test.go
+++ b/statusv1/scanner_test.go
@@ -1,0 +1,125 @@
+package statusv1
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_newZScanner(t *testing.T) {
+	testcases := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "mixed entries with rename",
+			input: " M file1.txt\x00R  new.txt\x00old.txt\x00A  file2.txt\x00",
+			want: []string{
+				" M file1.txt",
+				"R  new.txt\x00old.txt",
+				"A  file2.txt",
+			},
+		},
+		{
+			name:  "multiple renames",
+			input: "R  new1.txt\x00old1.txt\x00C  copy.txt\x00orig.txt\x00",
+			want: []string{
+				"R  new1.txt\x00old1.txt",
+				"C  copy.txt\x00orig.txt",
+			},
+		},
+		{
+			name:  "regular entries only",
+			input: " M file1.txt\x00A  file2.txt\x00?? untracked.txt\x00",
+			want: []string{
+				" M file1.txt",
+				"A  file2.txt",
+				"?? untracked.txt",
+			},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  []string{},
+		},
+		{
+			name:  "single rename at EOF without final NUL",
+			input: "R  new.txt\x00old.txt",
+			want: []string{
+				"R  new.txt\x00old.txt",
+			},
+		},
+		{
+			name:    "corrupted rename at EOF - missing second path",
+			input:   "R  new.txt\x00",
+			want:    []string{}, // should error, not return anything
+			wantErr: true,
+		},
+		{
+			name:    "corrupted copy at EOF - empty second path",
+			input:   "C  new.txt\x00\x00",
+			want:    []string{"C  new.txt\x00"},
+			wantErr: false, // This should be handled as valid (empty original path)
+		},
+		{
+			name:  "rename in Y position",
+			input: " R new.txt\x00old.txt\x00",
+			want: []string{
+				" R new.txt\x00old.txt",
+			},
+		},
+		{
+			name:  "copy in Y position",
+			input: " C copy.txt\x00orig.txt\x00",
+			want: []string{
+				" C copy.txt\x00orig.txt",
+			},
+		},
+		{
+			name:  "mixed entries with Y position rename",
+			input: " M file1.txt\x00 R new.txt\x00old.txt\x00A  file2.txt\x00",
+			want: []string{
+				" M file1.txt",
+				" R new.txt\x00old.txt",
+				"A  file2.txt",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := newZScanner(strings.NewReader(tc.input))
+			var got []string
+
+			for scanner.Scan() {
+				token := string(scanner.Bytes())
+				if token != "" {
+					got = append(got, token)
+				}
+			}
+
+			if err := scanner.Err(); err != nil {
+				if !tc.wantErr {
+					t.Fatalf("scanner error: %v", err)
+				}
+				return
+			}
+
+			if tc.wantErr {
+				t.Fatalf("expected error, got none")
+			}
+
+			if len(got) != len(tc.want) {
+				t.Errorf("got %d tokens, want %d: %v vs %v", len(got), len(tc.want), got, tc.want)
+				return
+			}
+
+			for i, want := range tc.want {
+				if got[i] != want {
+					t.Errorf("token %d: got %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}

--- a/statusv1/status.go
+++ b/statusv1/status.go
@@ -1,7 +1,3 @@
-// Package statusv1 provides the status codes used in Git porcelain=v1.
-//
-// Parsing of Git status output in porcelain=v1 format is currently
-// unimplemented in favor of the more modern porcelain=v2 format.
 package statusv1
 
 // State represents a single character from Git porcelain=v1 status codes.
@@ -27,3 +23,30 @@ const (
 	Untracked State = '?' // untracked files
 	Ignored   State = '!' // ignored files
 )
+
+// XYFlag represents the two-character status code in porcelain=v1 format.
+// The X position shows the status of the index, and the Y position shows
+// the status of the working tree.
+type XYFlag struct {
+	X State // index status
+	Y State // working tree status
+}
+
+// String returns the XY status as a two-character string.
+func (xy XYFlag) String() string { return string(xy.X) + string(xy.Y) }
+
+// Entry represents a single file entry in git status --porcelain=v1 output.
+type Entry struct {
+	XY       XYFlag // two-character status code
+	Path     string // current path of the file
+	OrigPath string // original path for renamed/copied files (empty if not renamed/copied)
+}
+
+// Status represents the parsed output of git status --porcelain=v1.
+//
+// The Header field contains any header lines from the output, which may be present
+// when using flags such as --branch.  These lines are always prefixed with `##`.
+type Status struct {
+	Headers []string // header lines (prefixed with `##`), if present
+	Entries []Entry  // file entries
+}

--- a/statusv1/status_test.go
+++ b/statusv1/status_test.go
@@ -1,0 +1,51 @@
+package statusv1
+
+import "testing"
+
+func TestXYFlag_String(t *testing.T) {
+	testcases := []struct {
+		name     string
+		xy       XYFlag
+		expected string
+	}{
+		{
+			name:     "modified in working tree",
+			xy:       XYFlag{X: Unmodified, Y: Modified},
+			expected: " M",
+		},
+		{
+			name:     "added to index",
+			xy:       XYFlag{X: Added, Y: Unmodified},
+			expected: "A ",
+		},
+		{
+			name:     "renamed",
+			xy:       XYFlag{X: Renamed, Y: Unmodified},
+			expected: "R ",
+		},
+		{
+			name:     "untracked",
+			xy:       XYFlag{X: Untracked, Y: Untracked},
+			expected: "??",
+		},
+		{
+			name:     "ignored",
+			xy:       XYFlag{X: Ignored, Y: Ignored},
+			expected: "!!",
+		},
+		{
+			name:     "modified both",
+			xy:       XYFlag{X: Modified, Y: Modified},
+			expected: "MM",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.xy.String()
+			if result != tc.expected {
+				t.Errorf("Expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements porcelain=v1 parsing in a fairly robust fashion, with similar architecture to the statusv2 parser.

Despite its many warts and inconsistencies, the porcelain=v1 format is a considerably simpler format (providing much less data), and remains the default when `--porcelain` is passed to git without an argument for reverse compatibility.

Notably, while I parse and extract the branch name, upstream name, and ahead/behind info from the --branch header in my usage of porcelain=v1 in github.com/mroth/scmpuff, it does not appear to be a part of the formal specification for porcelain=v1 which is guaranteed to not change, and is not documented anywhere in git docs, so I will likely leave that for application level code and omit from this library, and only provide the raw header data here to keep this as a pure parser. Users should prefer porcelain=v2 if they need branch data as it is provided in the specification.